### PR TITLE
Added the VPC params when calling the slack_notify_lambda module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,10 @@ module "slack_notify_lambda" {
   # underlying module doesn't like when `kms_key_arn` is `null`
   kms_key_arn = local.create_kms_key ? module.kms_key.key_arn : (var.kms_master_key_id == null ? "" : var.kms_master_key_id)
 
+  # if the Lambda should be deployed in a VPC use these
+  vpc_subnet_ids         = var.vpc_subnet_ids
+  vpc_security_group_ids = var.vpc_security_group_ids
+
   context = module.this.context
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -61,3 +61,15 @@ variable "slack_emoji" {
   description = "A custom emoji that will appear on Slack messages"
   default     = ":amazon-aws:"
 }
+
+variable "vpc_subnet_ids" {
+  description = "List of subnet ids when the notifying Lambda Function should run in the VPC. Usually private or intra subnets."
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of security group ids when the notifying Lambda Function should run in the VPC."
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
## what

- Added VPC params to be able to deploy the Slack notification Lambda inside VPC as well

## why

- PCI DSS requires any Lambda to be deployed inside a VPC

## references

- https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-pci-dss.html
