### PR TITLE
fix(notifications): logic for assigning subscriber emails

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,7 +180,7 @@ resource "aws_budgets_budget" "default" {
       subscriber_sns_topic_arns = local.notifications_enabled ? [
         module.sns_topic.sns_topic_arn
       ] : lookup(notification.value, "subscriber_sns_topic_arns", null)
-      subscriber_email_addresses = local.notifications_enabled ? null : lookup(notification.value, "subscriber_email_addresses", null)
+      subscriber_email_addresses = local.notifications_enabled ? lookup(notification.value, "subscriber_email_addresses", null) : null
     }
   }
 }


### PR DESCRIPTION
## what
* Reverses logic for assigning subscriber emails when notifications are enabled

## why
* Previously providing subscriber emails was not working due to only assigning those emails when `notifications_enabled` was false. This seems incorrect.
  *  I also checked that having both an SNS topic + subscriber emails assigned is not mutually exclusive, so this feels like the originally desired behavior and we just have the logic swapped. 
## references

## Refs
* None. 
