### PR TITLE
Add support for planned budgeting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -183,4 +183,15 @@ resource "aws_budgets_budget" "default" {
       subscriber_email_addresses = lookup(notification.value, "subscriber_email_addresses", null)
     }
   }
+
+  dynamic "planned_limit" {
+    for_each = lookup(each.value, "planned_limits", null) != null ? try(tolist(each.value.planned_limits), [
+      each.value.planned_limits
+    ]) : []
+    content {
+      start_time = planned_limit.value.start_time
+      amount     = planned_limit.value.amount
+      unit       = planned_limit.value.unit
+    }
+  }
 }


### PR DESCRIPTION
## what

This PR adds support for the planned budgeting method. It allows to set different budget limits for multiple time periods. E.g.:
- Q1: $1000
- Q2: $1500
- Q3: $2000
- Q4: $3000

## why

I need to create budgets with monthly planned limits

## references

[AWS Docs about planned budgeting method](https://docs.aws.amazon.com/cost-management/latest/userguide/budget-methods.html)
