### PR TITLE
Omit leading dash when module id is empty string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ module "slack_notify_lambda" {
 resource "aws_budgets_budget" "default" {
   for_each = local.budgets
 
-  name              = format("%s-%s", module.this.id, each.value.name)
+  name              = join("-", compact([module.this.id, each.value.name]))
   account_id        = lookup(each.value, "account_id", null)
   budget_type       = each.value.budget_type
   limit_amount      = each.value.limit_amount


### PR DESCRIPTION
## what

This PR fixes an issue with budget names. When module.this.id is an empty string then the budget name would always have a leading `-`. E.g. `-myBudgetName`.

The PR changes the way of merging strings from `format("%s-%s")` to using `join()` and `compact()` to ignore any empty string or null value.

## why

People may not set any labels which leads to a meaningless `-` prefix in the budget name

## references

closes #25 
